### PR TITLE
Loading & Querying 311 Data on Apache Spark

### DIFF
--- a/projects-in-this-repo/311_Exploratory-Analyses/.gitignore
+++ b/projects-in-this-repo/311_Exploratory-Analyses/.gitignore
@@ -1,0 +1,3 @@
+*.csv
+*.log
+metastore_db/

--- a/projects-in-this-repo/311_Exploratory-Analyses/spark.sh
+++ b/projects-in-this-repo/311_Exploratory-Analyses/spark.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+brew install apache-spark
+sudo mkdir /user
+sudo chown `whoami` /user
+mkdir -p /user/hive/warehouse
+spark-sql --packages com.databricks:spark-csv_2.11:1.3.0 -v -f spark.sql

--- a/projects-in-this-repo/311_Exploratory-Analyses/spark.sql
+++ b/projects-in-this-repo/311_Exploratory-Analyses/spark.sql
@@ -1,0 +1,8 @@
+DROP TABLE IF EXISTS calls_strings;
+CREATE TABLE calls_strings (case_id string, opened string, closed string, updated string, status string, status_notes string, responsible_agency string, category string, request_type string, request_details string, address string, supervisor_district string, neighborhood string, point string, source string, media_url string) 
+USING com.databricks.spark.csv
+OPTIONS (path "Case_Data_from_San_Francisco_311__SF311_.csv", header "true", mode "DROPMALFORMED"); -- some rows have the newline character character in the middle of the quoted free form text fields, which the Spark CSV plugin isn't able to handle at this time
+
+SELECT count(*) FROM calls_strings;
+
+SELECT request_type, count(*) AS total FROM calls_strings GROUP BY request_type ORDER BY total DESC;


### PR DESCRIPTION
This demonstrates that the entire dataset can be loaded and queried relatively quickly with modern big data tools.
The spark.sh shell script assumes Homebrew is installed on OS X and installs Apache Spark, loads the 311 CSV file into a table (in-memory) and runs the sample queries in spark.sql
